### PR TITLE
Fix database hang/freeze

### DIFF
--- a/application/server/server.js
+++ b/application/server/server.js
@@ -55,8 +55,7 @@ app.route(`/api/pests/`).get((req, res) => {
 
     const queryDB = async () => {
     try {
-      const client = await pool.connect();
-      const q = await client.query(query);
+      const q = await pool.query(query);
       console.log(q.rowCount);
       res.status(200).send(q.rows)
       
@@ -77,8 +76,7 @@ app.route(`/api/Thread/`).get((req, res) => {
 
     const queryDB = async () => {
     try {
-      const client = await pool.connect();
-      const q = await client.query(query);
+      const q = await pool.query(query);
       console.log(q.rows);
       res.status(200).send(q.rows)
       
@@ -101,8 +99,7 @@ app.route(`/api/summaryThreadList/`).get((req, res) => {
 
     const queryDB = async () => {
     try {
-      const client = await pool.connect();
-      const q = await client.query(query);
+      const q = await pool.query(query);
       console.log(q.rows);
       res.status(200).send(q.rows)
       
@@ -144,7 +141,6 @@ app.route('/api/pest/create').post((req, res) => {
 
   const queryDB = async () => {
     try {
-      await pool.connect();
       const q = await pool.query(query);
       console.log(q.command)
       res.status(201).send()
@@ -174,7 +170,6 @@ app.route('/api/pest/delete').delete((req, res) => {
 
   const queryDB = async () => {
     try {
-      await pool.connect();
       const q = await pool.query(query);
       console.log(q.command)
       res.status(201).send()
@@ -214,7 +209,6 @@ app.route('/api/pest/update').put((req, res) => {
                  
   const queryDB = async () => {
     try {
-      await pool.connect();
       const q = await pool.query(query);
       console.log(q.command)
       res.status(201).send()
@@ -245,8 +239,7 @@ app.route(`/api/pests/type`).get((req, res) => {
 
     const queryDB = async () => {
     try {
-      const client = await pool.connect();
-      const q = await client.query(query);
+      const q = await pool.query(query);
       console.log(q.rows);
       res.status(200).send(q.rows)
       
@@ -278,8 +271,7 @@ app.route(`/api/pests/severity`).get((req, res) => {
 
     const queryDB = async () => {
     try {
-      const client = await pool.connect();
-      const q = await client.query(query);
+      const q = await pool.query(query);
       console.log(q.rows);
       res.status(200).send(q.rows)
       


### PR DESCRIPTION
Found what was causing database requests to hang.

Node-PG pool clients were being created with `pool.connect` but they were not explicitly released after use, so the pool kept these clients available indefinitely. Using `pool.query` automatically releases these clients so the pool doesn't fill up and prevent new clients from being made.

Also removed standalone instances of `await pool.connect();`. These seemed to cause the same issues above and fill up the pool, but these clients could not be released.

This change should prevent database requests from hanging like we have been seeing.