### PR TITLE
Updated Activity Table to use PestReport table and report relevant info

### DIFF
--- a/application/client/src/app/activity.ts
+++ b/application/client/src/app/activity.ts
@@ -2,8 +2,12 @@ export interface Activity {
     activityid: string;
     activitytype: string;
     activityts: Date;
-    incidentid: string;
-    // threadid: string;
+    reportid: string;
+    pestname: string;
+    submitterid: string;
+    submitter: string;
+    pestdescription: Text;
+    reporttext: Text;
     // responseid: string;
     // feedbackid: string;
 }  

--- a/application/client/src/app/activity/activity.component.html
+++ b/application/client/src/app/activity/activity.component.html
@@ -1,22 +1,43 @@
 <table>
-  <caption style="font-weight: bold">Recent Activity</caption>
   <tr>
-    <th>Activity Type</th>
-    <th>Activity ID</th>
+    <th>Recent Activity</th>
   </tr>
   <tr *ngFor="let activity of activities">
-    <td>{{activity.activitytype}}</td>
     <a routerLink="/detail/{{activity.activityid}}">
-      <td>{{activity.activityid}}</td>
+      <td>{{activity.submitter}} reported a(n) {{activity.pestname}} at {{activity.activityts}}</td>
     </a>
   </tr>
 </table>
 
-<!-- <h2>Recent Neighborhood Activity</h2>
-<ul class="activities">
-  <li *ngFor="let activity of activities">
+
+
+<!-- Use with http://localhost:4200/activity_crud_test to test info from database-->
+
+<!-- <table>
+  <caption style="font-weight: bold">Recent Activity</caption>
+  <tr>
+    <th>Activity ID</th>
+    <th>Activity Type</th>
+    <th>Activity Timestamp</th>
+    <th>Report ID</th>
+    <th>Pest Name</th>
+    <th>Submitter ID</th>
+    <th>Submitter </th>
+    <th>Pest Description</th>
+    <th>Report Text</th>
+  </tr>
+  <tr *ngFor="let activity of activities">
     <a routerLink="/detail/{{activity.activityid}}">
-      <span class="badge">Type: {{activity.activitytype}} </span> <span class="badge">ID: {{activity.activityid}}</span>
+      <td>{{activity.activityid}}</td>
     </a>
-  </li>
-</ul> -->
+    <td>{{activity.activitytype}}</td>
+    <td>{{activity.activityts}}</td>
+    <td>{{activity.reportid}}</td>
+    <td>{{activity.pestname}}</td>
+    <td>{{activity.submitterid}}</td>
+    <td>{{activity.submitter}}</td>
+    <td>{{activity.pestdescription}}</td>
+    <td>{{activity.reporttext}}</td>
+  </tr>
+</table>
+ -->

--- a/application/server/csv/activity.csv
+++ b/application/server/csv/activity.csv
@@ -1,6 +1,6 @@
-ActivityID,ActivityType,ActivityTS,IncidentID
-0d925a22-f3de-4893-91b6-697a967bc46e,Incident,6/4/22,8d936d99-7477-43e0-bda3-3ab3cb0e805f
-f0732a26-3394-45b2-9826-ef7a326226d7,Incident,10/2/22,81a1fa97-5371-4bdc-adfe-84c96dade479
-074abb2f-af9e-4f16-bc9a-b2215e5b2315,Incident,9/26/22,a536984b-9fbb-4171-82a1-5db11fcfb6d3
-f25baf17-e7ac-43a0-8f17-cd1b5ce984d4,Incident,10/30/22,bc769e8f-821f-4f7d-9bc5-50cadcee72cd
-f593f5be-998b-4656-8b9b-50a57b031ff7,Incident,10/27/22,ab58951a-457d-4306-9b4b-546fe5eb0a8c
+ActivityID,ActivityType,ActivityTS,ReportID,PestName,SubmitterID,Submitter,PestDescription,ReportText
+0d925a22-f3de-4893-91b6-697a967bc46e,Incident,some_time,a5e2775c-6dad-436c-8d79-84fec90644f4,N/A,No_SubmitterID,Some_User,N/A,No Report Text
+f0732a26-3394-45b2-9826-ef7a326226d7,Incident,some_time,3690eb06-67b7-43a6-8ad9-7c7781431f64,N/A,No_SubmitterID,Some_User,N/A,No Report Text
+074abb2f-af9e-4f16-bc9a-b2215e5b2315,Incident,some_time,8ddb5502-44fd-4d96-b5fd-828c02f0dc50,N/A,No_SubmitterID,Some_User,N/A,No Report Text
+f25baf17-e7ac-43a0-8f17-cd1b5ce984d4,Incident,some_time,8277cb46-e9bf-468f-8289-428e10a5a7ae,N/A,No_SubmitterID,Some_User,N/A,No Report Text
+f593f5be-998b-4656-8b9b-50a57b031ff7,Incident,some_time,f426dc1b-0856-4475-a331-931bd390f768,N/A,No_SubmitterID,Some_User,N/A,No Report Text

--- a/application/server/database-run.sh
+++ b/application/server/database-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rm -rf data
+echo "data/ removed"
+nohup docker compose up > ~/log.out &
+tail -f ~/log.out


### PR DESCRIPTION
Schema.sql- changed Activity table to use PestReport table for relevant info, and to update using ReportID from .csv file.

Actvity.TS and Activity.Component.HTML- updated frontend to display a message about activity update with relevant info. Put generic info in the CSV file to use if the PestReport table didn't contain something.

database-run.sh- included a small script to just remove the data dir, and run the docker compose. We can take it or leave it, it's just made my life easier

For now I only have information about pest reports; I'm working on getting thread activities in there too.