### PR TITLE
Lukas/activity table

### DIFF
--- a/application/client/src/app/activity.ts
+++ b/application/client/src/app/activity.ts
@@ -6,9 +6,8 @@ export interface Activity {
     pesttype: string;
     submitterid: string;
     submitter: string;
-    pestdescription: Text;
-    reporttext: Text;
-    threadID: string;
-    // responseid: string;
-    // feedbackid: string;
+    outmessage: Text;
+    incidentid: string;
+    threadid: string;
+    threadsubject: Text;
 }  

--- a/application/client/src/app/activity/activity.component.css
+++ b/application/client/src/app/activity/activity.component.css
@@ -3,6 +3,10 @@
 table, th, td {
   border: 1px solid;
 }
+
+.clicker {
+  cursor: pointer;
+}
 /* .activities {
     margin: 0 0 2em 0;
     list-style-type: none;

--- a/application/client/src/app/activity/activity.component.html
+++ b/application/client/src/app/activity/activity.component.html
@@ -2,12 +2,15 @@
   <tr>
     <th>Recent Activity</th>
   </tr>
+  <!-- <tr><button (click)="this.printItem()">Debug Print</button></tr> -->
   <div *ngFor="let activity of activities">
     <tr>
       <!-- <a routerLink="/detail/{{activity.activityid}}"> -->
-      <a routerLink="/expanded-discussion-view">
-        <td>New {{activity.activitytype}}: {{activity.submitter}} reported a(n) {{activity.pesttype}}</td>
+      <div class="clicker" (click)="this.printItem(activity.threadid)">
+        <a routerLink="/forum">
+        <td>{{activity.submitter}} {{activity.outmessage}}</td>
       </a>
+      </div>
     </tr>
   </div>  
 </table>

--- a/application/client/src/app/activity/activity.component.ts
+++ b/application/client/src/app/activity/activity.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { Activity } from '../activity';
 import { ActivityService } from '../activity.service';
+import { SummaryThreadService } from '../summary-thread.service';
 
 @Component({
   selector: 'app-activity',
@@ -12,7 +13,7 @@ export class ActivityComponent implements OnInit {
   activities: Activity[] = [];
   activity!: Activity;
 
-  constructor(private activityService: ActivityService) { }
+  constructor(public summaryThreadService: SummaryThreadService, private activityService: ActivityService) { }
 
   ngOnInit(): void {
     this.getActivities();
@@ -28,29 +29,35 @@ export class ActivityComponent implements OnInit {
 
   }
 
+  printItem(thread_id: string): void {
+    //var temp = 'b981e06d-fdc2-48ac-ba21-06c29bbd6e64'; //test
+    // this.summaryThreadService.expandThread(temp.toString()); //test
+    this.summaryThreadService.expandThread(thread_id.toString());
+  }
+
 
 //Finish CRUD operations
-createActivity(at: string, rid: string, pt: string, sid: string, sub: string, pd: Text, rt: Text){
-  this.activity.activitytype = at;
-  this.activity.reportid = rid;
-  this.activity.pesttype = pt;
-  this.activity.submitterid = sid;
-  this.activity.submitter = sub;
-  this.activity.pestdescription = pd;
-  this.activity.reporttext = rt;
+// createActivity(at: string, rid: string, pt: string, sid: string, sub: string, pd: Text, rt: Text){
+//   this.activity.activitytype = at;
+//   this.activity.reportid = rid;
+//   this.activity.pesttype = pt;
+//   this.activity.submitterid = sid;
+//   this.activity.submitter = sub;
+//   this.activity.reporttext = rt;
 
-  console.log(this.activity);
-  this.activityService.createActivity(this.activity).subscribe(
-  async data => {});
-  alert("The Activity has been created");
-  this.activity.activitytype = "";
-  this.activity.reportid = "";
-  this.activity.pesttype = "";
-  this.activity.submitterid = "";
-  this.activity.submitter = "";
-  this.activity.pestdescription = null;
-  this.activity.reporttext = null;
-}
+//   console.log(this.activity);
+//   this.activityService.createActivity(this.activity).subscribe(
+//   async data => {});
+//   alert("The Activity has been created");
+//   this.activity.activitytype = "";
+//   this.activity.reportid = "";
+//   this.activity.pesttype = "";
+//   this.activity.submitterid = "";
+//   this.activity.submitter = "";
+//   this.activity.reporttext = null;
+// }
+
+
 /*
 createActivity(activity: Activity): Array<Activity> {
     this.activityService.createActivity(activity)

--- a/application/client/src/app/expanded-discussion-view/expanded-discussion-view.component.html
+++ b/application/client/src/app/expanded-discussion-view/expanded-discussion-view.component.html
@@ -14,30 +14,31 @@
     <div class="originalThread shadow">
         <div class="stPestImage">
             <!-- <img src={{this.getReceivedThreadItem().pestimage}} alt="Pest Icon" class="stPestImageFormats"> -->
-            <img src={{this.responseList[0].pestimage}} alt="Pest Icon" class="stPestImageFormats">
+            <!-- <img src={{this.responseList[0].pestimage}} alt="Pest Icon" class="stPestImageFormats"> -->
+            <img src={{this.originalMessage().pestimage}} alt="Pest Icon" class="stPestImageFormats">
         </div>
         <div class="stTitle p1">
             <!-- <span class="head1">{{this.getReceivedThreadItem().subject}}</span> -->
-            <span class="head1">{{this.responseList[0].subject}}</span>
+            <span class="head1">{{this.originalMessage().subject}}</span>
         </div>
         <div class="stDescription p1">
             <!-- <span class="p1">{{this.getReceivedThreadItem().comment}}</span> -->
-            <span class="p1">{{this.responseList[0].comment}}</span>
+            <span class="p1">{{this.originalMessage().comment}}</span>
         </div>
         <div class="feedback p1 brightness">
             <!-- <img src="../assets/form_controls/Icon_Thumbs_Up_Gray.png" class="fcfeedback" alt="uVote">
             <img src="../assets/form_controls/Icon_Thumbs_Down_Gray.png" class="fcfeedback" alt="dVote"> -->
-            <span *ngIf="this.responseList[0].currentuserfeedback == 2; else notPositive">
-                <img src="../assets/form_controls/Icon_Thumbs_Up_Blue.png" class="fcfeedback" alt="uVoteActive" (click)="this.upVote(this.responseList[0].currentuserfeedback, this.responseList[0].threadid)">
+            <span *ngIf="this.originalMessage().currentuserfeedback == 2; else notPositive">
+                <img src="../assets/form_controls/Icon_Thumbs_Up_Blue.png" class="fcfeedback" alt="uVoteActive" (click)="this.upVote(this.originalMessage().currentuserfeedback, this.originalMessage().threadid)">
             </span>
             <ng-template #notPositive>
-                <img src="../assets/form_controls/Icon_Thumbs_Up_Gray.png" class="fcfeedback" alt="uVoteInactive" (click)="this.upVote(this.responseList[0].currentuserfeedback, this.responseList[0].threadid)">
+                <img src="../assets/form_controls/Icon_Thumbs_Up_Gray.png" class="fcfeedback" alt="uVoteInactive" (click)="this.upVote(this.originalMessage().currentuserfeedback, this.originalMessage().threadid)">
             </ng-template>
-            <span *ngIf="this.responseList[0].currentuserfeedback == 1; else notNegative">
-                <img src="../assets/form_controls/Icon_Thumbs_Down_Red.png" class="fcfeedback" alt="dVoteActive" (click)="this.downVote(this.responseList[0].currentuserfeedback, this.responseList[0].threadid)">
+            <span *ngIf="this.originalMessage().currentuserfeedback == 1; else notNegative">
+                <img src="../assets/form_controls/Icon_Thumbs_Down_Red.png" class="fcfeedback" alt="dVoteActive" (click)="this.downVote(this.originalMessage().currentuserfeedback, this.originalMessage().threadid)">
             </span>
             <ng-template #notNegative>
-                <img src="../assets/form_controls/Icon_Thumbs_Down_Gray.png" class="fcfeedback" alt="dVoteInactive" (click)="this.downVote(this.responseList[0].currentuserfeedback, this.responseList[0].threadid)">
+                <img src="../assets/form_controls/Icon_Thumbs_Down_Gray.png" class="fcfeedback" alt="dVoteInactive" (click)="this.downVote(this.originalMessage().currentuserfeedback, this.originalMessage().threadid)">
             </ng-template>
             <img src="../assets/form_controls/Icon_Pest_Info.png" class="fcfeedbackbutton" alt="pestInfo" (click)="this.openPestInfoWindow()">
         </div>

--- a/application/client/src/app/expanded-discussion-view/expanded-discussion-view.component.ts
+++ b/application/client/src/app/expanded-discussion-view/expanded-discussion-view.component.ts
@@ -167,10 +167,10 @@ export class ExpandedDiscussionViewComponent implements OnInit {
       comment: 'delete request',
     }
 
+    console.log("Deleting response feedback for: " + repInfo.responseid);
+    this.expThreadService.deleteResponseFeedback(repInfo).subscribe(async data => {});
+
     console.log("Deleting response: " + repInfo.responseid);
-
-    // this.expThreadService.deleteResponse(repInfo).subscribe(async data => {});
-
     this.expThreadService.deleteResponse(repInfo).subscribe(
     (data)=>{
       console.log(data);

--- a/application/client/src/app/expanded-discussion-view/expanded-discussion-view.component.ts
+++ b/application/client/src/app/expanded-discussion-view/expanded-discussion-view.component.ts
@@ -10,6 +10,7 @@ import { responses, responseTable, newResponse, feedback } from "../expanded-thr
 import { ExpandedThreadService } from "../expanded-thread.service";
 import { PestInfoComponent } from '../pest-info/pest-info.component';
 import { CurrentUser } from '../login'
+import { UserinfoService } from '../userinfo.service';
 import { UserinfocardComponent } from '../userinfocard/userinfocard.component';
 import { UserInfo, CurrentUser_t } from '../userinfo';
 
@@ -42,11 +43,11 @@ export class ExpandedDiscussionViewComponent implements OnInit {
   public mtData: CurrentUser_t;
   
   constructor(private sumThreadService:SummaryThreadService, public expThreadService: ExpandedThreadService,
-    private  dialogRef: MatDialog, private router: Router, public infoCard: MatDialog) { 
-    this.signedInUser = this.generateUser();
+    private dialogRef: MatDialog, private router: Router, public infoCard: MatDialog, public uiService: UserinfoService) { 
   }
 
   ngOnInit(): void {
+    this.signedInUser = this.uiService.activeUser();
     this.receivedThreadItem = this.sumThreadService.getSelectedThreadItem();
     // console.log("exp service thread id: " + this.expThreadService.selectedThread.threadid);
     // this.receivedThreadItem = this.expThreadService.selectedThread;
@@ -78,6 +79,10 @@ export class ExpandedDiscussionViewComponent implements OnInit {
     });
 
     console.log("Selected comp thread: " + this.modalThread);
+  }
+
+  originalMessage(): responses {
+    return this.responseList[0];
   }
 
   generateUser(): CurrentUser {
@@ -304,12 +309,12 @@ export class ExpandedDiscussionViewComponent implements OnInit {
   }
   
   printResponse(): void {
-    console.log("click even triggered");
+    console.log("image value: " + this.responseList[0].pestimage);
   }
 
   openPestInfoWindow(): void {
     this.dialogRef.open(PestInfoComponent, {
-      data: {incidentID: this.receivedThreadItem.incidentid}
+      data: {incidentID: this.originalMessage().incidentid}
     });
   }
 

--- a/application/client/src/app/expanded-thread.service.ts
+++ b/application/client/src/app/expanded-thread.service.ts
@@ -83,6 +83,16 @@ deleteResponse(response: responseTable): Observable<responseTable> {
     catchError(this.handleError<responseTable>('delete response')));
 }
 
+deleteResponseFeedback(response: responseTable): Observable<responseTable> {
+
+  console.log("response id: " + response.responseid);
+
+  return this.http.post<responseTable>('http://localhost:8080/api/deleteFeedbackRecordMulti/', response)
+  .pipe(
+    tap(_ => this.log(`deleting response for ${response.threadid}`)), // TODO: determine which id this returns
+    catchError(this.handleError<responseTable>('delete response')));
+}
+
 deleteThread(response: responseTable): Observable<responseTable> {
 
   console.log("response id: " + response.responseid);

--- a/application/client/src/app/forum/forum.component.html
+++ b/application/client/src/app/forum/forum.component.html
@@ -30,7 +30,7 @@
                 <!-- <button class="menuButton" (click)="this.testIt(summaryThread_Prev.threadid)">Index</button> -->
             </div>
             <div class="stActivity">
-                <span>Views: {{summaryThread_Prev.record_count}} / Responses: {{summaryThread_Prev.record_count}}</span>
+                <span>Responses: {{summaryThread_Prev.response_count}}</span>
             </div>
             <div class="stRating">
                 <span>Positive Feedback: {{summaryThread_Prev.total_positive}} <span class="tab4"></span>Quality Rating: 

--- a/application/client/src/app/forum/forum.component.ts
+++ b/application/client/src/app/forum/forum.component.ts
@@ -7,6 +7,7 @@ import { ExpandedThreadService} from '../expanded-thread.service';
 import { ThreadComponent } from '../thread/thread.component';
 import { CurrentUser } from '../login'
 import { UserinfocardComponent } from '../userinfocard/userinfocard.component';
+import { UserinfoService } from '../userinfo.service';
 import { UserInfo, CurrentUser_t } from '../userinfo';
 import { identifierName } from '@angular/compiler';
 
@@ -46,10 +47,10 @@ export class ForumComponent implements OnInit {
 
   
   constructor(public summaryThreadService: SummaryThreadService, public expThreadService: ExpandedThreadService,
-    public threadCreationWindow: MatDialog, public infoCard: MatDialog) {}
+    public threadCreationWindow: MatDialog, public infoCard: MatDialog, public uiService: UserinfoService) {}
   
   ngOnInit(pestTypeFilter: string = ""): void {
-    this.currentUser = this.generateUser(); //temp -- be sure to replace when permanent method is developed
+    this.currentUser = this.uiService.activeUser(); //temp -- be sure to replace when permanent method is developed
 
     if(pestTypeFilter.length > 0)
     {
@@ -223,6 +224,11 @@ export class ForumComponent implements OnInit {
       id => {this.createFirstThreadResponse(id);});
 
 
+    console.log("on step 2 - adding activity");
+
+    this.summaryThreadService.addNewActivity(newThreadData).subscribe(
+      (data)=>{});
+
     console.log("outside function ntidString: " + this.ntidString);
 
   }
@@ -243,11 +249,8 @@ export class ForumComponent implements OnInit {
   }
 
   printItem(): void {
-    // console.log("threadID value: " + this.ntidString);
-    // console.log("Creation timestampe: " + this.creationTimeStamp);
-    //var temp = 'a2954011-5a55-4548-a162-d0f61b2f1ad7'; //test 6
-    var temp = '6e3da37a-78d7-4cd0-9f6b-31fba6371cf5'; //test 8
-    this.summaryThreadService.expandThread(temp.toString());
+    console.log("current user: " + this.currentUser.username);
+    console.log("current user (service): " + this.uiService.activeUser().username);
   }
 
   testIt(arrayId: string)

--- a/application/client/src/app/nav/nav.component.css
+++ b/application/client/src/app/nav/nav.component.css
@@ -37,3 +37,13 @@
 .example-spacer{
   flex: 1 1 auto;
 }
+
+.currentUser {
+  width: 100%;
+  height: 25px;
+  font-weight: bold;
+  text-align: center;
+  /* margin-left: 15px; */
+  /* margin-top: 8px; */
+
+}

--- a/application/client/src/app/nav/nav.component.html
+++ b/application/client/src/app/nav/nav.component.html
@@ -5,6 +5,10 @@
       [opened]="(isHandset$ | async) === false">
     <mat-toolbar>Menu</mat-toolbar>
     <mat-nav-list class="activity-box">
+      <div class="currentUser">
+        <mat-label id="user_name" name="username" [formControl]="user_name">User: {{this.user_name.value}}</mat-label>
+      </div>
+
       <!-- Activity:
       <mat-list-item class="activity-item">Welcome to Pest Patrol user!</mat-list-item> -->
       <app-activity></app-activity>
@@ -34,11 +38,17 @@
       </button> -->
       <span>Pest Patrol</span>
       <div class="top-buttons">
+        <button mat-button [matMenuTriggerFor]="menu">Select Another User</button>
+        <mat-menu #menu="matMenu">
+          <button *ngFor="let listItem of this.userList" (click)="this.signInUser(this.listItem)" mat-menu-item>{{this.listItem.username}}</button>
+        </mat-menu>
       <mat-list-item><button routerLink="/login">Login</button></mat-list-item>
       <mat-list-item><button routerLink="/register">Register</button></mat-list-item>
       </div>
+
     </mat-toolbar>
-    
+
    <!-- The map -->
    <router-outlet></router-outlet>
 </mat-sidenav-container>
+

--- a/application/client/src/app/nav/nav.component.ts
+++ b/application/client/src/app/nav/nav.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Observable } from 'rxjs';
 import { map, shareReplay } from 'rxjs/operators';
-
+import { Router } from '@angular/router';
+import { UserInfo, UserInfoThread, UserAccountInfo } from '../userinfo';
+import { CurrentUser } from '../login';
+import { UserinfoService } from '../userinfo.service';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-nav',
@@ -17,10 +21,41 @@ export class NavComponent {
       shareReplay()
     );
 
-  constructor(private breakpointObserver: BreakpointObserver) {}
+  public activeUser: CurrentUser;
+  public userList: UserAccountInfo[] = [];
+  public listItem: UserAccountInfo;
+  public userListSelection: UserAccountInfo;
+  public user_name = new FormControl('');
 
+  constructor(private breakpointObserver: BreakpointObserver, public uiService: UserinfoService,
+    public router: Router) {
+    this.activeUser = uiService.activeUser();
+  }
 
+  ngOnInit() {
+    this.getUserList();
+    this.user_name.setValue(this.activeUser.username);
+  }
 
+  signInUser(newUser: UserAccountInfo): void {
+    let temp: CurrentUser = {
+      userid: newUser.userid,
+      username: newUser.username,
+    }
 
+    this.activeUser = temp;
+    this.uiService.saveToLocalStorage(this.activeUser);
+
+    this.router.routeReuseStrategy.shouldReuseRoute = () => false;
+    this.router.onSameUrlNavigation = 'reload';
+    this.router.navigate(['../forum']);
+
+    this.ngOnInit();
+  }
+
+  getUserList(): void {
+    console.log("getting registered users");
+    this.uiService.getRegisteredUsers().subscribe(data => this.userList = data);
+  }
 
 }

--- a/application/client/src/app/summary-thread.service.ts
+++ b/application/client/src/app/summary-thread.service.ts
@@ -180,12 +180,22 @@ export class SummaryThreadService {
       console.log("subject(title): " + newThreadData.subject);
       console.log("comment: " + newThreadData.comment);
       
-      return this.http.post<ThreadID>('http://localhost:8080/api/thread/addCreationThread', newThreadData)
+      return this.http.post<ThreadID>('http://localhost:8080/api/thread/addNewThread', newThreadData)
       .pipe(
         tap(_ => this.log(`adding thread for incident id: ${newThreadData.incidentid}`)),
         catchError(this.handleError<ThreadID>('create thread')));
     }
 
+    addNewActivity(newThreadData: NewThreadData): Observable<ThreadID> {
+      console.log("incident(report) id: " + newThreadData.incidentid);
+      console.log("subject(title): " + newThreadData.subject);
+      console.log("comment: " + newThreadData.comment);
+      
+      return this.http.post<ThreadID>('http://localhost:8080/api/thread/addCreationThread', newThreadData)
+      .pipe(
+        tap(_ => this.log(`adding thread for incident id: ${newThreadData.incidentid}`)),
+        catchError(this.handleError<ThreadID>('create thread')));
+    }
     
     getThreadID(pRepID: PestRepID): Observable<PestRepID> {
       console.log("report id: " + pRepID.reportid);

--- a/application/client/src/app/summary-thread.ts
+++ b/application/client/src/app/summary-thread.ts
@@ -1,20 +1,3 @@
-// export interface SummaryThread_Prev {
-//     threadid: string; 
-//     incidentid: number;
-//     locid: number;
-//     creatorid: string;
-//     createdate: Date;
-//     subject: string;
-//     comment: string;
-//     imagepath: string;
-//     iconpath: string;
-//     record_count: number;
-//     total_positive: number;
-//     reportdate: Date;
-//     pestid: string;
-//     pesttype: string;
-//     username: string;
-// }
 
 export interface SummaryThread_Prev {
     reportid: string;
@@ -35,6 +18,7 @@ export interface SummaryThread_Prev {
     pesttype: string;
     pestid: string;
     username: string;
+    response_count: number;
 }
 
 

--- a/application/client/src/app/userinfo.service.ts
+++ b/application/client/src/app/userinfo.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CurrentUser } from './login';
-import { UserInfo, UserInfoThread } from './userinfo';
+import { UserInfo, UserInfoThread, UserAccountInfo } from './userinfo';
 import { Observable, of, BehaviorSubject } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 
@@ -11,16 +11,28 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 })
 export class UserinfoService {
 
-  constructor(private http: HttpClient) { }
+
+  constructor(private http: HttpClient) {
+      // if(this.activeUser() == null || this.activeUser() == undefined)
+      // {
+      //   console.log("No users signed-in.  Setting current user to readonly");
+      //   this.signedInUser = this.notSignedIn();
+      // }
+      // else
+      // {
+      //   console.log("Existing user session found.  Restoring user...");
+      //   this.signedInUser = this.activeUser();
+      // }
+      
+   }
 
   httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };
 
-
   /** Log a SummaryThreadService message with the MessageService */
   private log(message: string) {
-    console.log(`SummaryThreadService: ${message}`);
+    console.log(`UserInfo: ${message}`);
   }
 
     /**
@@ -42,6 +54,36 @@ export class UserinfoService {
         return of(result as T);
       };
     }
+
+  notSignedIn(): CurrentUser {
+    let temp: CurrentUser = {
+      userid: "00000000-0000-0000-0000-000000000000",
+      username: "Not_Signed_In",
+    }
+
+    return temp;
+  }
+
+  saveToLocalStorage(currentSessionUser: CurrentUser): void {
+    localStorage.setItem('activeUser', JSON.stringify(currentSessionUser));
+  }
+
+  activeUser(): CurrentUser {
+    let user: CurrentUser = JSON.parse(localStorage.getItem('activeUser'));
+
+    if(user == null || user == undefined)
+      return this.notSignedIn();
+    else
+      return user;
+  }
+
+  getRegisteredUsers(): Observable<UserAccountInfo[]> {
+  
+    return this.http.get<UserAccountInfo[]>('http://localhost:8080/api/users')
+    .pipe(
+      tap(_ => this.log(`getting list of registered users`)),
+      catchError(this.handleError<UserAccountInfo[]>('getting user data')));
+  }
 
 
   getUserInfo(selectedUser: CurrentUser): Observable<UserInfo> {

--- a/application/client/src/app/userinfo.ts
+++ b/application/client/src/app/userinfo.ts
@@ -19,3 +19,14 @@ export class CurrentUser_t {
     username: string;
     threadid: string;
   }
+
+  export class UserAccountInfo {
+    userid: string;
+    locid: string;
+    username: string;
+    email: string;
+    usertype: string;
+    firstname: string;
+    lastname: string;
+    password: string;
+  }

--- a/application/server/schema.sql
+++ b/application/server/schema.sql
@@ -103,18 +103,20 @@ CREATE TABLE IF NOT EXISTS PestReport (
 
 CREATE TABLE IF NOT EXISTS Activity (
   ActivityID UUID UNIQUE PRIMARY KEY DEFAULT uuid_generate_v4 (),
-  ActivityType VARCHAR(255), -- IncidentReport, ThreadCreate, ThreadResponse, ThreedFeedback, etc.
+  ActivityType VARCHAR(255),
   ActivityTS TIMESTAMP,
   ReportID UUID,
   PestID UUID,
   PestType VARCHAR(255),
-  SubmitterID VARCHAR(100),
+  SubmitterID UUID,
   Submitter VARCHAR(100),
-  PestDescription TEXT,
-  ReportText TEXT,
-  ThreadID UUID
---   ResponseID UUID, --NULL
---   FeedbackID UUID--NULL
+  OutMessage VARCHAR(500),
+  IncidentID UUID,
+  ThreadID UUID,
+  ThreadSubject VARCHAR(100),
+  LocID UUID,
+  XCoord FLOAT,
+  YCoord FLOAT
 );
 
 COPY Neighborhood FROM '/docker-entrypoint-initdb.d/csv/neighborhood.csv' CSV HEADER;

--- a/application/server/server.js
+++ b/application/server/server.js
@@ -176,15 +176,34 @@ app.route(`/api/Thread/`).get((req, res) => {
 //get summary thread list
 app.route(`/api/summaryThreadList/`).get((req, res) => {
 
+    // query = `SELECT pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username AS ReportSubmitterUsername, 
+    // pestreport.reportdate AS RepCreationDate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, 
+    // pestreport.reporttext AS iconPath, Count(threadfeedback.feedbackid) as Record_Count, 
+    // coalesce(Sum(abs(threadfeedback.positive::int)),0) as Total_Positive, pest.pesttype, pest.pestid, users.username
+    // FROM (pest INNER JOIN (pestreport LEFT JOIN ((thread LEFT JOIN threadfeedback ON thread.threadid = threadfeedback.threadid) LEFT JOIN 
+    // users ON thread.creatorid = users.userid) ON pestreport.incidentid = thread.incidentid) ON pest.pestid = pestreport.pestid) LEFT JOIN 
+    // users AS users_1 ON pestreport.submitterid = users_1.userid
+    // GROUP BY pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username, 
+    // pestreport.reportdate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, pest.pesttype, pest.pestid, users.username
+    // ORDER BY pestreport.reportdate DESC;`
+
     query = `SELECT pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username AS ReportSubmitterUsername, 
     pestreport.reportdate AS RepCreationDate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, 
     pestreport.reporttext AS iconPath, Count(threadfeedback.feedbackid) as Record_Count, 
-    coalesce(Sum(abs(threadfeedback.positive::int)),0) as Total_Positive, pest.pesttype, pest.pestid, users.username
-    FROM (pest INNER JOIN (pestreport LEFT JOIN ((thread LEFT JOIN threadfeedback ON thread.threadid = threadfeedback.threadid) LEFT JOIN 
+    coalesce(Sum(abs(threadfeedback.positive::int)),0) as Total_Positive, pest.pesttype, pest.pestid, users.username, reply_count.response_count
+    FROM ((pest INNER JOIN (pestreport LEFT JOIN ((thread LEFT JOIN threadfeedback ON thread.threadid = threadfeedback.threadid) LEFT JOIN 
     users ON thread.creatorid = users.userid) ON pestreport.incidentid = thread.incidentid) ON pest.pestid = pestreport.pestid) LEFT JOIN 
-    users AS users_1 ON pestreport.submitterid = users_1.userid
+    users AS users_1 ON pestreport.submitterid = users_1.userid) LEFT JOIN
+    (select threadresponse.threadid, 
+      coalesce(Sum(case threadresponse.comment
+          when 'Original_Thread' then 0
+          else 1
+          end),0) as response_count
+      from threadresponse
+      group by threadresponse.threadid) as reply_count on thread.threadid = reply_count.threadid
     GROUP BY pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username, 
-    pestreport.reportdate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, pest.pesttype, pest.pestid, users.username
+    pestreport.reportdate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, pest.pesttype, pest.pestid, users.username,
+    reply_count.response_count
     ORDER BY pestreport.reportdate DESC;`
 
     const queryDB = async () => {
@@ -209,16 +228,36 @@ app.route(`/api/summaryThreadList/pestType`).post((req, res) => {
   console.log(req.headers.pesttype);
   console.log('--------------------------------------- TEST ---------------------------------------');
 
+  // query = `SELECT pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username AS ReportSubmitterUsername, 
+  // pestreport.reportdate AS RepCreationDate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, 
+  // '../../assets/Incident_Report_Images/Incident_Coyote.png' AS iconPath, Count(threadfeedback.feedbackid) as Record_Count, 
+  // coalesce(Sum(abs(threadfeedback.positive::int)),0) as Total_Positive, pest.pesttype, pest.pestid, users.username
+  // FROM (pest INNER JOIN (pestreport LEFT JOIN ((thread LEFT JOIN threadfeedback ON thread.threadid = threadfeedback.threadid) LEFT JOIN 
+  // users ON thread.creatorid = users.userid) ON pestreport.incidentid = thread.incidentid) ON pest.pestid = pestreport.pestid) LEFT JOIN 
+  // users AS users_1 ON pestreport.submitterid = users_1.userid
+  // where (((pest.pesttype)='${req.body.pesttype}'))
+  // GROUP BY pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username, 
+  // pestreport.reportdate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, pest.pesttype, pest.pestid, users.username
+  // ORDER BY pestreport.reportdate DESC;`
+
   query = `SELECT pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username AS ReportSubmitterUsername, 
   pestreport.reportdate AS RepCreationDate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, 
-  '../../assets/Incident_Report_Images/Incident_Coyote.png' AS iconPath, Count(threadfeedback.feedbackid) as Record_Count, 
-  coalesce(Sum(abs(threadfeedback.positive::int)),0) as Total_Positive, pest.pesttype, pest.pestid, users.username
-  FROM (pest INNER JOIN (pestreport LEFT JOIN ((thread LEFT JOIN threadfeedback ON thread.threadid = threadfeedback.threadid) LEFT JOIN 
+  pestreport.reporttext AS iconPath, Count(threadfeedback.feedbackid) as Record_Count, 
+  coalesce(Sum(abs(threadfeedback.positive::int)),0) as Total_Positive, pest.pesttype, pest.pestid, users.username, reply_count.response_count
+  FROM ((pest INNER JOIN (pestreport LEFT JOIN ((thread LEFT JOIN threadfeedback ON thread.threadid = threadfeedback.threadid) LEFT JOIN 
   users ON thread.creatorid = users.userid) ON pestreport.incidentid = thread.incidentid) ON pest.pestid = pestreport.pestid) LEFT JOIN 
-  users AS users_1 ON pestreport.submitterid = users_1.userid
-  where (((pest.pesttype)='${req.body.pesttype}'))
+  users AS users_1 ON pestreport.submitterid = users_1.userid) LEFT JOIN
+  (select threadresponse.threadid, 
+    coalesce(Sum(case threadresponse.comment
+        when 'Original_Thread' then 0
+        else 1
+        end),0) as response_count
+    from threadresponse
+    group by threadresponse.threadid) as reply_count on thread.threadid = reply_count.threadid
+  WHERE (((pest.pesttype)='${req.body.pesttype}'))
   GROUP BY pestreport.reportid, pestreport.incidentid, thread.threadid, pestreport.locid, pestreport.submitterid, users_1.username, 
-  pestreport.reportdate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, pest.pesttype, pest.pestid, users.username
+  pestreport.reportdate, thread.creatorid, thread.createdate, thread.subject, thread.comment, pestreport.pestimage, pest.pesttype, pest.pestid, users.username,
+  reply_count.response_count
   ORDER BY pestreport.reportdate DESC;`
 
   const queryDB = async () => {
@@ -321,6 +360,29 @@ queryDB();
 })
 
 //Create new discussion thread -- Step 3: add new record to thread table
+app.route(`/api/thread/addNewThread`).post((req, res) => {
+
+  query = `insert into thread ( incidentid, locid, creatorid, createdate, subject, comment)
+  select '${req.body.incidentid}' as incidentid, '${req.body.locid}' as locid, 
+  '${req.body.creatorid}' as creatorid, '${req.body.createdate}' as createdate, '${req.body.subject}' as title,
+  '${req.body.comment}' as comment
+  returning threadid;`
+
+  const queryDB = async () => {
+    try {
+        const q = await pool.query(query);
+        console.log("logging threadid: " + q.rows[0].threadid);
+        res.status(201).send(q.rows[0]); //returns thread id of newly created thread record
+      } catch (err) {
+        console.log(err);
+        res.status(500).send()
+      }
+  };
+
+  queryDB();
+})
+
+//Create new thread activity record -- Step 3: add new record to activity table
 app.route(`/api/thread/addCreationThread`).post((req, res) => {
 
   console.log('--------------------------------------- step 3 test ---------------------------------------');
@@ -331,12 +393,6 @@ app.route(`/api/thread/addCreationThread`).post((req, res) => {
   console.log(req.body.subject);
   console.log(req.body.comment);
   console.log('--------------------------------------- step 3 test ---------------------------------------');
-
-  query = `insert into thread ( incidentid, locid, creatorid, createdate, subject, comment)
-  select '${req.body.incidentid}' as incidentid, '${req.body.locid}' as locid, 
-  '${req.body.creatorid}' as creatorid, '${req.body.createdate}' as createdate, '${req.body.subject}' as title,
-  '${req.body.comment}' as comment
-  returning threadid;`
 
   query2 = `INSERT INTO activity(submitterid,submitter,reporttext,activitytype,activityts,pestid,pesttype)
   VALUES('${req.body.creatorid}',
@@ -358,24 +414,12 @@ app.route(`/api/thread/addCreationThread`).post((req, res) => {
          WHERE Activity.PestID = Pest.PestID;`
 
 
-  const queryDB = async () => {
-    try {
-        const q = await pool.query(query);
-        console.log("logging threadid: " + q.rows[0].threadid);
-        //res.status(201).send(q.rows[0].threadid);
-        res.status(201).send(q.rows[0]);
-        //res.status(201).send(q.rows);
-      } catch (err) {
-        console.log(err);
-        res.status(500).send()
-      }
-  };
   const queryDB2 = async () => {
     try {
         const q = await pool.query(query2);
         console.log("logging activity: ");
         //res.status(201).send(q.rows[0].threadid);
-        res.status(201).send(q.rows[0]);
+        res.status(201).send();
         //res.status(201).send(q.rows);
       } catch (err) {
         console.log(err);
@@ -383,7 +427,6 @@ app.route(`/api/thread/addCreationThread`).post((req, res) => {
       }
   };
 
-  queryDB();
   queryDB2();
 })
 
@@ -808,9 +851,12 @@ app.route(`/api/userThreadMetrics`).post((req, res) => {
 })
 
 
+//get user data
 app.route(`/api/users`).get((req, res) => {
 
-  query = `select userid, username from users;`
+  query = `select users.userid, users.locid, users.username, users.email, 
+  users.usertype, users.firstname, users.lastname, users.password
+  from users;`
 
   const queryDB = async () => {
     try {
@@ -825,6 +871,7 @@ app.route(`/api/users`).get((req, res) => {
    
   queryDB();
 })
+
 
 // Add a new pest
 app.route('/api/pest/create').post((req, res) => {

--- a/application/server/server.js
+++ b/application/server/server.js
@@ -599,6 +599,30 @@ app.route(`/api/deleteThreadResponse`).post((req, res) => {
   queryDB();
 })
 
+//Clear feedback data
+app.route(`/api/deleteFeedbackRecordMulti`).post((req, res) => {
+
+  console.log('--------------------------------------- Delete Response Feedback Test ---------------------------------------');
+  console.log(req.body.responseid);
+  console.log('--------------------------------------- Delete Response Feedback Test ---------------------------------------');
+  
+  query = `delete from threadfeedback where threadfeedback.responseid = '${req.body.responseid}';`;
+  
+  const queryDB = async () => {
+    try {
+      const q = await pool.query(query);
+      console.log(q.command)
+      res.status(201).send()
+    } catch (err) {
+      console.log(err);
+      res.status(500).send()
+    }
+  };
+
+  queryDB();
+})
+
+
 //Delete thread
 app.route(`/api/deleteThread`).post((req, res) => {
 

--- a/website/secure_html/Prototype.html
+++ b/website/secure_html/Prototype.html
@@ -178,9 +178,6 @@
       <iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTChra_voRpy7ob5tbQ-apMJNGEzgA7l_pVyZLIuk2Bg21ETHe7_0yV94xaxgps4fdxw3PI_niLjBW9/pubhtml?gid=1845396651&amp;single=true&amp;widget=true&amp;headers=false" width="1280" height="620"></iframe>
     </center>
   </div>
-    <center>
-      <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTp0SKsTrQxdKwmGCkoI2JkRYHEBz6HoRTY6y0iAove7s_rCIELdZZj3Ln3-fDDmXoDEOGyQD9y-4rP/embed?start=false&loop=false&delayms=3000" frameborder="0" width="1100" height="650" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
-    </center>
   <hr></hr>
   <!-- Demo 1 -->
   <div id="Container_Subhead">
@@ -217,6 +214,9 @@
     <p>Final Presentation</p>
   </div>
   <div id="Container_Content">
+    <center>
+      <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vRZqNFxzv5FD--apDTZcHb--Au23fPFaPdhmLfD8QcaiJmpGpZK1P0TXhr6cUpoEG6-1Sk27k3x0CVI/embed?start=false&loop=false&delayms=3000" frameborder="0" width="1100" height="650" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+    </center>
   </div>
   <hr></hr>
 </div>

--- a/website/secure_html/labs.html
+++ b/website/secure_html/labs.html
@@ -173,25 +173,25 @@
       <center>
         <h4>Bryan Burton</h4>
           <a href="https://drive.google.com/file/d/1tMkVijfspX_2YH8oThBefL9biIuvDvTo/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
-          <a href="" class="w3-btn">Lab 2 Final</a>
+          <a href="https://drive.google.com/file/d/1Ru5T9i-05Bad8TNjKf9uYGyyyxu8V6yA/view?usp=sharing" class="w3-btn">Lab 2 Final</a>
         <h4>Tom Cooch</h4>
           <a href="https://drive.google.com/file/d/1rQ_SdZfuec3N1K3cHcrW22CgukSdhEn6/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
-          <a href="" class="w3-btn">Lab 2 Final</a>
+          <a href="https://drive.google.com/file/d/1UrkbXsSLm601uaC9MwLqmB0OajR5G9yU/view?usp=sharing" class="w3-btn">Lab 2 Final</a>
         <h4>Trevor Hess</h4>
           <a href="https://drive.google.com/file/d/1eccj9gqrvJdm4e3D0trKG1OLv3R0eLmA/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
           <a href="" class="w3-btn">Lab 2 Final</a>
         <h4>Heather Mallalieu</h4>
           <a href="https://drive.google.com/file/d/191U4l7mtIiLJKOMWbkGa-MIET0WAMOuG/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
-          <a href="" class="w3-btn">Lab 2 Final</a>
+          <a href="https://drive.google.com/file/d/1YXgpJ_kolqdN0qMEaR7Kl9aojsT-Y2Gx/view?usp=sharing" class="w3-btn">Lab 2 Final</a>
         <h4>Anton Rasmussen</h4>
           <a href="https://drive.google.com/file/d/192mjMSeBp7kXvWi3WRHBGN25WlZuSvj-/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
-          <a href="" class="w3-btn">Lab 2 Final</a>
+          <a href="https://drive.google.com/file/d/1fkykWZ48tKbTluwnYKRdKrRhvJ-mF9D_/view?usp=sharing" class="w3-btn">Lab 2 Final</a>
         <h4>Andrew Undercoffer</h4>
           <a href="https://drive.google.com/file/d/1IVxjxOOEDDeF3SBi_GQatboXX3GZqTCA/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
-          <a href="" class="w3-btn">Lab 2 Final</a>
+          <a href="https://drive.google.com/file/d/1M9m8pyGD-N9IvrDiycf6dVxvSyr_st9C/view?usp=sharing" class="w3-btn">Lab 2 Final</a>
         <h4>Val Vega</h4>
           <a href="https://drive.google.com/file/d/1iIBAiHYnNPHJa5fFvjch5qWn_aGbWyWw/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
-          <a href="" class="w3-btn">Lab 2 Final</a>
+          <a href="https://drive.google.com/file/d/1mN6-NGhegGdW-lxNe3ey7-984_Wi6dZ0/view?usp=sharing" class="w3-btn">Lab 2 Final</a>
         <h4>Lukas McKennedy</h4>
           <a href="https://drive.google.com/file/d/1Ep2ShcGGFbNwYdnLI0FzgK6LLo6OYZmu/view?usp=sharing" class="w3-btn">Lab 2 Draft</a>
           <a href="" class="w3-btn">Lab 2 Final</a>
@@ -210,7 +210,11 @@
     </br> 
     <hr></hr>
     <center><h3> Lab 3</h3></center>
-    <center><iframe width="70%" height="500px" src="https://docs.google.com/document/d/e/2PACX-1vSGtfRTT4_irwBBg5vYIF3F_SMH3AZ689Mif0xgPiRsvp8WyaSAe7rbAb68vw5iIIJmQ49GFqAKwGCN/pub?embedded=true"></iframe></center>
+    <center>
+      <iframe width="70%" height="500px" src="https://docs.google.com/document/d/e/2PACX-1vSGtfRTT4_irwBBg5vYIF3F_SMH3AZ689Mif0xgPiRsvp8WyaSAe7rbAb68vw5iIIJmQ49GFqAKwGCN/pub?embedded=true"></iframe>
+      </br></br>
+      <a href="https://drive.google.com/file/d/1x3TESzUIj2Vh_7wUnPQ0K-x1vBWcaFCK/view?usp=sharing" class="w3-btn">Lab 3 PDF</a>
+    </center>
     </br>
   </section>
 
@@ -223,25 +227,33 @@
     <center><h3> Lab 4 - Collaborative Outline </h3></center>
     <center><iframe width="70%" height="500px" src="https://docs.google.com/document/d/e/2PACX-1vTS1xDVE32GQ45ly4TSZ5sUcTp7EnbGZidt25y17yDZeL9YCDlih8Us5KzRa5jpXbsg2_6SbQ-o45o7/pub?embedded=true"></iframe></center>
     </br>
+    <hr></hr>
+    <center><h3> Lab 4</h3></center>
+    <center>
+      <iframe width="70%" height="500px" src="https://docs.google.com/document/d/e/2PACX-1vQWJtwS2pVJWzzWfgcjgo3-gYUBhKv7EgbHWiS4LcUueKRJ7IMuSMPq-64zAvEZf8zMsnSY5bZvnX9R/pub?embedded=true"></iframe>
+      </br></br>
+      <a href="https://drive.google.com/file/d/1a7_3VVcSQhXW0RtYxSRGVXIjlJsuZUuk/view?usp=sharing" class="w3-btn">Lab 4 PDF</a>
+    </center>
+    </br>
   </section>
 
 
 	<br></br>
-  <footer id="myFooter">
-    <div class="w3-container w3-theme-l2 w3-padding-32">
-      <h4>Pest Patrol</h4>
-    </div>
-    <div class="w3-container w3-theme-l1">
-      <p>Powered By: 
-        <a href="https://odu.edu/" target="_blank">ODU</a>
-        <a href="https://odu.edu/compsci" target="_blank">CS 411</a>
-        <a href="https://www.cs.odu.edu/~410black/the_team.html" target="_blank">Team Black</a>
-      </p>
-    </div>
-  </footer>
+
 </center>
 </div>
-
+<footer id="myFooter">
+  <div class="w3-container w3-theme-l2 w3-padding-32">
+    <h4>Pest Patrol</h4>
+  </div>
+  <div class="w3-container w3-theme-l1">
+    <p>Powered By: 
+      <a href="https://odu.edu/" target="_blank">ODU</a>
+      <a href="https://odu.edu/compsci" target="_blank">CS 411</a>
+      <a href="https://www.cs.odu.edu/~410black/the_team.html" target="_blank">Team Black</a>
+    </p>
+  </div>
+</footer>
 <!-- END MAIN -->
 
 


### PR DESCRIPTION
Not sure if the actual user login functionality is going to be implemented for me to get that data, but the neighborhood activity table should be fully functioning with this, i.e. it updates with new pest reports, threads, and thread responses, displays the correct message with both, and when clicked directs you to either the forum or the expanded discussion view based on the activity. 

Still working on enhancing it and getting the rest of the data in there for "data science purposes", but at least this PR should get it working for the demo.